### PR TITLE
Improve CMake project, make it plug and play when added as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,61 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(quickpool VERSION 1.2.0)
 
-## Project-wide setup
+project(quickpool VERSION 1.5.0)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
+option(QUICKPOOL_TEST          "Build test" ON)
+option(QUICKPOOL_TEST_SANITIZE "Build test with sanitizer" OFF)
+
+find_library(LIB_ATOMIC
+  NAMES
+    "atomic"
+    "libatomic.so"
+    "libatomic.so.1"
+)
+
 find_package(Threads)
 
-add_executable(test test.cpp)
-target_link_libraries(test ${CMAKE_THREAD_LIBS_INIT})
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_libraries(test "-latomic")
+add_library(quickpool
+  INTERFACE
+    "quickpool.hpp"
+)
+
+target_include_directories(quickpool
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(quickpool
+  INTERFACE
+    $<$<BOOL:${LIB_ATOMIC}>:${LIB_ATOMIC}>
+    $<TARGET_NAME_IF_EXISTS:Threads::Threads>
+)
+
+if(QUICKPOOL_TEST)
+  add_executable(test "test.cpp")
+
+  target_link_libraries(test
+    PRIVATE
+      quickpool
+  )
+
+  if(QUICKPOOL_TEST_SANITIZE)
+    target_compile_options(test
+      PRIVATE
+        "-fno-omit-frame-pointer"
+        "-fsanitize=address,undefined,leak,bounds,alignment"
+    )
+
+    target_link_options(test
+      PRIVATE
+        "-fno-omit-frame-pointer"
+        "-fsanitize=address,undefined,leak,bounds,alignment"
+    )
+  endif()
 endif()
-
-# set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address,undefined,leak,bounds,alignment")
-# set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address,undefined,leak,bounds,alignment")
-
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
Using the header-only library in a CMake project is now straightforward:

```cmake
add_subdirectory(quickpool)
add_executable(exe main.cpp)
target_link_libraries(exe quickpool)
```

Library users previously had to link to `Threads::Threads` and `libatomic` manually.
Also, the include directory is added to the target's search path automatically.