### PR TITLE
Enable CTest and use it in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,15 +56,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      if: runner.os == 'Windows'
-      run: "Release/test.exe"
-
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      if: runner.os != 'Windows'
-      run: ./test
+      run: ctest --build-config ${{matrix.config.build_type}} --verbose
 
     - name: Get code coverage
       working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,21 +35,28 @@ target_link_libraries(quickpool
 )
 
 if(QUICKPOOL_TEST)
-  add_executable(test "test.cpp")
+  include(CTest)
 
-  target_link_libraries(test
+  add_executable(quickpool_test "test.cpp")
+
+  add_test(
+    NAME quickpool_test
+    COMMAND "quickpool_test"
+  )
+
+  target_link_libraries(quickpool_test
     PRIVATE
       quickpool
   )
 
   if(QUICKPOOL_TEST_SANITIZE)
-    target_compile_options(test
+    target_compile_options(quickpool_test
       PRIVATE
         "-fno-omit-frame-pointer"
         "-fsanitize=address,undefined,leak,bounds,alignment"
     )
 
-    target_link_options(test
+    target_link_options(quickpool_test
       PRIVATE
         "-fno-omit-frame-pointer"
         "-fsanitize=address,undefined,leak,bounds,alignment"


### PR DESCRIPTION
The test's target is renamed because the name `test` is reserved with CTest.