### PR TITLE
Don't produce warnings in downstream projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,17 @@ find_library(LIB_ATOMIC
 
 find_package(Threads)
 
-add_library(quickpool
-  INTERFACE
-    "quickpool.hpp"
-)
+add_library(quickpool INTERFACE)
+
+if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  # Project built standalone
+  set(SYSTEM "")
+else()
+  set(SYSTEM "SYSTEM")
+endif()
 
 target_include_directories(quickpool
-  INTERFACE
+  ${SYSTEM} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
With these changes, the include directory for `quickpool` will be marked as a system directory, if it is not built standalone. This will effectively prevent any warnings from being shown to downstream projects that simply include the respective header in their code (which may compile with higher warning levels).